### PR TITLE
fix: explicit the workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reopening as it skipped the release-please-action because the commit wasn't conventional.