### PR TITLE
fix!: remove data hash argument from ItaxCode.valid? and ItaxCode::Validator#valid?

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ ItaxCode.encode(
   birthdate: "1980-01-01", # String|Time|Date|DateTime
   birthplace: "Milano" # Name(Milano)|code(F205)
 )
+
+# Output
+#
+# "RSSMRA80A01F205X"
 ```
 
 ### Decode
@@ -197,16 +201,11 @@ ItaxCode.decode("RSSMRA80A01F205X")
 ### Validate
 
 ```ruby
-ItaxCode.valid?(
-  "RSSMRA80A01F205X",
-  {
-    surname: "Rossi",
-    name: "Mario",
-    gender: "M",
-    birthdate: "1980-01-01",
-    birthplace: "Milano"
-  }
-)
+ItaxCode.valid?("RSSMRA80A01F205X")
+
+# Output
+#
+# true
 ```
 
 ## Development

--- a/lib/itax_code.rb
+++ b/lib/itax_code.rb
@@ -12,7 +12,7 @@ module ItaxCode
   Error = Class.new(StandardError)
 
   class << self
-    # Encodes user tax code.
+    # Encodes the user tax code.
     #
     # @param [Hash] data The user attributes
     #
@@ -27,7 +27,7 @@ module ItaxCode
       Encoder.new(data).encode
     end
 
-    # Decodes tax code in its components.
+    # Decodes the tax code in its components.
     #
     # @param [String] tax_code The user tax code
     #
@@ -36,21 +36,13 @@ module ItaxCode
       Parser.new(tax_code).decode
     end
 
-    # Checks the given tax code validity against new one
-    # encoded from user informations.
+    # Checks the given tax code validity.
     #
     # @param [String] tax_code The user tax code
-    # @param [Hash]   data     The optional user attributes
-    #
-    # @option data [String]       :surname
-    # @option data [String]       :name
-    # @option data [String]       :gender
-    # @option data [String, Date] :birthdate
-    # @option data [String]       :birthplace
     #
     # @return [Boolean]
-    def valid?(tax_code, data = {})
-      Validator.new(tax_code, data).valid?
+    def valid?(tax_code)
+      Validator.new(tax_code).valid?
     end
   end
 end

--- a/lib/itax_code/encoder.rb
+++ b/lib/itax_code/encoder.rb
@@ -3,12 +3,6 @@
 module ItaxCode
   # Handles the tax code generation logic.
   #
-  # @param [String]       surname    The user first name
-  # @param [String]       name       The user last name
-  # @param [String]       gender     The user gender
-  # @param [String, Date] birthdate  The user birthdate
-  # @param [String]       birthplace The user birthplace
-  #
   # @example
   #   ItaxCode::Encoder.new(
   #     surname: "Rossi",
@@ -22,16 +16,24 @@ module ItaxCode
   class Encoder
     MissingDataError = Class.new(StandardError)
 
+    # @param [Hash]  data  The user attributes
+    # @param [Utils] utils
+    #
+    # @option data [String]       :surname    The user first name
+    # @option data [String]       :name       The user last name
+    # @option data [String]       :gender     The user gender
+    # @option data [String, Date] :birthdate  The user birthdate
+    # @option data [String]       :birthplace The user birthplace
     def initialize(data = {}, utils = Utils.new)
       @surname    = data[:surname]
       @name       = data[:name]
       @gender     = data[:gender]&.upcase
       @birthdate  = data[:birthdate].to_s
       @birthplace = data[:birthplace]
-      @utils      = utils
       validate_data_presence!
 
       @birthdate = parse_birthdate!
+      @utils     = utils
     end
 
     # Computes the tax code from its components.

--- a/lib/itax_code/parser.rb
+++ b/lib/itax_code/parser.rb
@@ -5,19 +5,19 @@ require "itax_code/omocode"
 module ItaxCode
   # Handles the parsing logic.
   #
-  # @param [String] tax_code
-  #
   # @example
   #
   #   ItaxCode::Parser.new("RSSMRA70A01L726S").decode
   #
-  # @return [Hash]
+  # @return [Hash] The parsed tax code
   class Parser
     Error                             = Class.new(StandardError)
     NoTaxCodeError                    = Class.new(Error)
     InvalidControlInternalNumberError = Class.new(Error)
     InvalidTaxCodeError               = Class.new(Error)
 
+    # @param [String] tax_code
+    # @param [Utils]  utils
     def initialize(tax_code, utils = Utils.new)
       @tax_code = tax_code&.upcase
       raise NoTaxCodeError if @tax_code.blank?

--- a/lib/itax_code/validator.rb
+++ b/lib/itax_code/validator.rb
@@ -2,23 +2,16 @@
 
 module ItaxCode
   # Handles the validation logic.
-  #
-  # @param [Hash] data The user input data
   class Validator
-    LENGTH        = 16
-    REQUIRED_KEYS = %i[surname name gender birthdate birthplace].freeze
+    LENGTH = 16
 
     # @param [String] tax_code The pre-computed tax code
-    # @param [Hash]   data     The optional user attributes
-    #
-    def initialize(tax_code, data = {})
+    def initialize(tax_code)
       @tax_code = tax_code
-      @data     = data
     end
 
     class << self
-      # Checks the tax code standard length against user
-      # and business fiscal code standards.
+      # Checks the tax code standard length against user and business fiscal code standards.
       #
       # @param [String] tax_code The tax code
       #
@@ -32,24 +25,12 @@ module ItaxCode
     #
     # @return [true, false]
     def valid?
-      encoded_tax_code == tax_code
+      !decoded_tax_code.nil?
     end
 
     private
 
-      attr_reader :tax_code, :data
-
-      # Encodes the tax code from the given 'data' hash, also backfilling missing information
-      # by decoding the pre-computed tax code.
-      #
-      # @return [String, nil] The encoded tax code or nil if decoding the tax code fails
-      def encoded_tax_code
-        if partial_data?
-          decoded_tax_code ? backfill_data! : return
-        end
-
-        Encoder.new(data).encode
-      end
+      attr_reader :tax_code
 
       # Decodes the given tax code to backfill possibly missing data in the 'data' hash.
       # If the decode fails, it means that the provided tax code is not valid.
@@ -60,20 +41,6 @@ module ItaxCode
           Parser.new(tax_code).decode
         rescue Parser::Error
           nil
-        end
-      end
-
-      def partial_data?
-        REQUIRED_KEYS.any? { |required_key| data[required_key].blank? }
-      end
-
-      def backfill_data!
-        data.tap do |hash|
-          hash[:surname]    ||= decoded_tax_code[:raw][:surname]
-          hash[:name]       ||= decoded_tax_code[:raw][:name]
-          hash[:gender]     ||= decoded_tax_code[:gender]
-          hash[:birthdate]  ||= decoded_tax_code[:birthdate]
-          hash[:birthplace] ||= decoded_tax_code[:birthplace][:code]
         end
       end
   end

--- a/test/itax_code/validator_test.rb
+++ b/test/itax_code/validator_test.rb
@@ -12,22 +12,8 @@ module ItaxCode
       assert_equal %i[standard_length?], class_methods
     end
 
-    test "#valid? is truthy when data matches with the provided tax code" do
-      assert_predicate Validator.new("RSSMRA80A01F205X", data), :valid?
-    end
-
-    test "#valid? is truthy with matching partial and backfilled data" do
-      data_combos.each do |data_combo|
-        assert_predicate Validator.new("RSSMRA80A01F205X", data_combo), :valid?
-      end
-    end
-
-    test "#valid? is truthy when the tax code is valid and no data is provided" do
+    test "#valid? is truthy when the tax code can be decoded" do
       assert_predicate Validator.new("RSSMRA80A01F205X"), :valid?
-    end
-
-    test "#valid? is falsy when data don't matches with the provided tax code" do
-      assert_not Validator.new("RSSMRA11A01F205F", data).valid?
     end
 
     test "#valid? is falsy when the parser cannot decode the given tax code" do
@@ -41,26 +27,5 @@ module ItaxCode
     test "#standard_length? is falsy when the tax code hasn't 16 chars" do
       assert_not Validator.standard_length?("WRONG")
     end
-
-    private
-
-      def data
-        {
-          surname: "Rossi",
-          name: "Mario",
-          gender: "M",
-          birthdate: "1980-01-01",
-          birthplace: "Milano"
-        }
-      end
-
-      # Creates all the possible combinations from the 'data' hash.
-      def data_combos
-        (1..data.keys.size).flat_map do |size|
-          data.keys.combination(size).map do |keys|
-            keys.map { |key| [key, data[key]] }.to_h
-          end
-        end
-      end
   end
 end

--- a/test/itax_code_test.rb
+++ b/test/itax_code_test.rb
@@ -20,16 +20,7 @@ class ItaxCodeTest < ActiveSupport::TestCase
   end
 
   test "#valid?" do
-    assert klass.valid?(
-      "RSSMRA80A10F205Z",
-      {
-        surname: "Rossi",
-        name: "Mario",
-        gender: "M",
-        birthdate: Date.new(1980, 1, 10),
-        birthplace: "Milano"
-      }
-    )
+    assert klass.valid?("RSSMRA80A10F205Z")
   end
 
   private


### PR DESCRIPTION
Fixes #29

---

**This PR introduces a breaking change, so a bump to the next major is necessary.**

The `.valid?` method checks a pre-computed tax code against another one encoded from an user-provided hash of data. This check isn't reliable as it only checks the exact equality between the pre-computed tax code and the newly encoded one, returning false negatives for different but still valid tax codes (including omocodes).

This PR simplifies the validity checks by dropping the data hash argument and validating just the provided tax code leveraging the decoder capabilities.