### PR TITLE
refactor: make gem errors inherit from base classes

### DIFF
--- a/lib/itax_code.rb
+++ b/lib/itax_code.rb
@@ -6,10 +6,9 @@ require "itax_code/version"
 require "itax_code/utils"
 require "itax_code/encoder"
 require "itax_code/parser"
+require "itax_code/error"
 
 module ItaxCode
-  Error = Class.new(StandardError)
-
   class << self
     # Encodes the user tax code.
     #

--- a/lib/itax_code/encoder.rb
+++ b/lib/itax_code/encoder.rb
@@ -14,9 +14,6 @@ module ItaxCode
   #
   # @return [String] The encoded tax code
   class Encoder
-    Error            = Class.new(StandardError)
-    MissingDataError = Class.new(Error)
-
     # @param [Hash]  data  The user attributes
     # @param [Utils] utils
     #

--- a/lib/itax_code/encoder.rb
+++ b/lib/itax_code/encoder.rb
@@ -97,7 +97,7 @@ module ItaxCode
       def parse_birthdate!
         Date.parse(birthdate)
       rescue StandardError
-        raise ArgumentError, "#{birthdate} is not a valid date"
+        raise InvalidBirthdateError, "#{birthdate} is not a valid date"
       end
   end
 end

--- a/lib/itax_code/encoder.rb
+++ b/lib/itax_code/encoder.rb
@@ -14,7 +14,8 @@ module ItaxCode
   #
   # @return [String] The encoded tax code
   class Encoder
-    MissingDataError = Class.new(StandardError)
+    Error            = Class.new(StandardError)
+    MissingDataError = Class.new(Error)
 
     # @param [Hash]  data  The user attributes
     # @param [Utils] utils

--- a/lib/itax_code/error.rb
+++ b/lib/itax_code/error.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ItaxCode
+  Error = Class.new(StandardError)
+
+  class Encoder
+    Error = Class.new(StandardError)
+
+    MissingDataError = Class.new(Error)
+  end
+
+  class Parser
+    Error = Class.new(StandardError)
+
+    InvalidControlInternalNumberError = Class.new(Error)
+    InvalidTaxCodeError = Class.new(Error)
+    NoTaxCodeError = Class.new(Error)
+  end
+end

--- a/lib/itax_code/error.rb
+++ b/lib/itax_code/error.rb
@@ -4,13 +4,13 @@ module ItaxCode
   Error = Class.new(StandardError)
 
   class Encoder
-    Error = Class.new(StandardError)
+    Error = Class.new(Error)
 
     MissingDataError = Class.new(Error)
   end
 
   class Parser
-    Error = Class.new(StandardError)
+    Error = Class.new(Error)
 
     InvalidControlInternalNumberError = Class.new(Error)
     InvalidTaxCodeError = Class.new(Error)

--- a/lib/itax_code/error.rb
+++ b/lib/itax_code/error.rb
@@ -6,6 +6,7 @@ module ItaxCode
   class Encoder
     Error = Class.new(Error)
 
+    InvalidBirthdateError = Class.new(Error)
     MissingDataError = Class.new(Error)
   end
 

--- a/lib/itax_code/parser.rb
+++ b/lib/itax_code/parser.rb
@@ -11,11 +11,6 @@ module ItaxCode
   #
   # @return [Hash] The parsed tax code
   class Parser
-    Error                             = Class.new(StandardError)
-    NoTaxCodeError                    = Class.new(Error)
-    InvalidControlInternalNumberError = Class.new(Error)
-    InvalidTaxCodeError               = Class.new(Error)
-
     LENGTH = 16
 
     # @param [String] tax_code

--- a/test/itax_code/encoder_test.rb
+++ b/test/itax_code/encoder_test.rb
@@ -73,7 +73,7 @@ module ItaxCode
     end
 
     test "#encode raises ArgumentError on malformed birthdate" do
-      assert_raises ArgumentError do
+      assert_raises Encoder::InvalidBirthdateError do
         Encoder.new(
           surname: "Rossi",
           name: "Mario",


### PR DESCRIPTION
The new error hierarchy would look like this:

```
ItaxCode::Error
└── ItaxCode::Encoder::Error
    └── ItaxCode::Encoder::SomeError
└── ItaxCode::Parser::Error
    └── ItaxCode::Parser::SomeError
└── ...
```