### PR TITLE
fix: require the csv gem as runtime dependency

### DIFF
--- a/itax_code.gemspec
+++ b/itax_code.gemspec
@@ -25,4 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.metadata["rubygems_mfa_required"] = "false"
+
+  # CSV 3.1.7 is the first version requiring Ruby >= 2.5.0
+  spec.add_runtime_dependency "csv", "~> 3.0", ">= 3.1.7"
 end


### PR DESCRIPTION
From 3.4 onwards, `csv` has been pulled out the standard lib, and has to be explicitly added to the bundle.