### PR TITLE
fix: parsing impossible dates

### DIFF
--- a/lib/itax_code/error.rb
+++ b/lib/itax_code/error.rb
@@ -16,5 +16,6 @@ module ItaxCode
     InvalidControlInternalNumberError = Class.new(Error)
     InvalidTaxCodeError = Class.new(Error)
     NoTaxCodeError = Class.new(Error)
+    DateTaxCodeError = Class.new(Error)
   end
 end

--- a/lib/itax_code/parser.rb
+++ b/lib/itax_code/parser.rb
@@ -83,11 +83,9 @@ module ItaxCode
       end
 
       def birthdate
-        begin
-          @birthdate ||= Date.parse("#{year}-#{month}-#{day}").to_s
-        rescue Date::Error
-          raise DateTaxCodeError
-        end
+        @birthdate ||= Date.parse("#{year}-#{month}-#{day}").to_s
+      rescue Date::Error
+        raise DateTaxCodeError
       end
 
       def birthplace(src = utils.cities, stop: false)

--- a/lib/itax_code/parser.rb
+++ b/lib/itax_code/parser.rb
@@ -83,7 +83,11 @@ module ItaxCode
       end
 
       def birthdate
-        @birthdate ||= Date.parse("#{year}-#{month}-#{day}").to_s
+        begin
+          @birthdate ||= Date.parse("#{year}-#{month}-#{day}").to_s
+        rescue Date::Error
+          raise DateTaxCodeError
+        end
       end
 
       def birthplace(src = utils.cities, stop: false)

--- a/lib/itax_code/parser.rb
+++ b/lib/itax_code/parser.rb
@@ -84,7 +84,7 @@ module ItaxCode
 
       def birthdate
         @birthdate ||= Date.parse("#{year}-#{month}-#{day}").to_s
-      rescue Date::Error
+      rescue ArgumentError
         raise DateTaxCodeError
       end
 

--- a/test/itax_code/parser_test.rb
+++ b/test/itax_code/parser_test.rb
@@ -48,6 +48,12 @@ module ItaxCode
       assert_raises(klass::InvalidTaxCodeError) { klass.new(wrong_length_tax_code) }
     end
 
+    test "raises DateTaxCodeError with an invalid date, e.g. 1978-4-31" do
+      wrong_month_tax_code = "SPENTB78D71D612X"
+
+      assert_raises(klass::DateTaxCodeError) { klass.new(wrong_month_tax_code).decode }
+    end
+
     test "raises InvalidControlInternalNumberError when the cin differs from the computed one" do
       tax_code_with_wrong_cin = "CCCFBA85D03L219Z"
 


### PR DESCRIPTION
Ciao, facendo delle prove mi sono accorto che nel caso in cui venga indicata una data impossibile (ad esempio il 30 febbraio) la decodifica andava in errore:
`/Users/domenico/.rvm/gems/ruby-3.2.3@faker/gems/itax_code-2.0.4/lib/itax_code/parser.rb:86:in `parse': invalid date (Date::Error)

        @birthdate ||= Date.parse("#{year}-#{month}-#{day}").to_s
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^
	from /Users/domenico/.rvm/gems/ruby-3.2.3@faker/gems/itax_code-2.0.4/lib/itax_code/parser.rb:86:in `birthdate'
	from /Users/domenico/.rvm/gems/ruby-3.2.3@faker/gems/itax_code-2.0.4/lib/itax_code/parser.rb:34:in `decode'
	from /Users/domenico/.rvm/gems/ruby-3.2.3@faker/gems/itax_code-2.0.4/lib/itax_code.rb:32:in `decode'
	from /Users/domenico/.rvm/gems/ruby-3.2.3@faker/gems/itax_code-2.0.4/lib/itax_code.rb:41:in `valid?'
	from aa.rb:7:in `block in <main>'
	from aa.rb:4:in `times'
	from aa.rb:4:in `<main>'`

ho corretto il bug e aggiunto un test