### PR TITLE
Add 'csv' gem in Gemfile for Ruby 3.4+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, head]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, head]
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "byebug"
+gem "csv"
 gem "minitest"
 gem "mocha"
 gem "rake"

--- a/itax_code.gemspec
+++ b/itax_code.gemspec
@@ -25,7 +25,4 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.metadata["rubygems_mfa_required"] = "false"
-
-  # CSV 3.1.7 is the first version requiring Ruby >= 2.5.0
-  spec.add_runtime_dependency "csv", "~> 3.0", ">= 3.1.7"
 end


### PR DESCRIPTION
Starting from Ruby 3.4.0, the `csv` library is no longer part of the default gems,
even though it is still part of the standard library.

This change ensures that the gem continues to work without warnings or load errors
by explicitly declaring `csv`.

Reference: https://stdgems.org/csv/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded compatibility testing to include Ruby 3.4 for improved coverage.
  
- **Chores**
  - Updated dependency management by adding a CSV library and streamlining the dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->