### PR TITLE
fix(deps): add openssl gem to Gemfile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true
+          bundler-cache: false
           ruby-version: 2.5.0
       - run: bundle install
       - run: bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 gem "byebug"
 gem "minitest"
 gem "mocha"
+gem "openssl"
 gem "rake"
 gem "rubocop"
 gem "rubocop-minitest"


### PR DESCRIPTION
Running `rake cities:import` with modern Rubies, I guess >= 3.4, errors with:

```
rake aborted!
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 peeraddr=185.199.110.133:443 state=error: certificate verify failed (unable to get certificate CRL) (OpenSSL::SSL::SSLError)
...
```

Because `openssl` is no longer part of the bundled gems.

This PR adds the dependency explicitly to the Gemfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an OpenSSL dependency to the project to support cryptographic operations.
  * Adjusted CI Ruby setup to disable dependency caching; this may increase build time but ensures fresh dependency installs for each run.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->