### PR TITLE
fix(parser): raise InvalidTaxCodeError when birthplace not found

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ ItaxCode.decode(tax_code) #=> Hash:
 #   code:       String,          # the input code, upcased
 #   gender:     "M" | "F",
 #   birthdate:  String,          # "YYYY-MM-DD"
-#   birthplace: {                # nil if not found in either CSV
+#   birthplace: {                # raises InvalidTaxCodeError if not found in either CSV
 #     code:       String,        # e.g. "F205"
 #     province:   String,        # e.g. "MI"
 #     name:       String,        # e.g. "MILANO"

--- a/lib/itax_code/parser.rb
+++ b/lib/itax_code/parser.rb
@@ -92,10 +92,12 @@ module ItaxCode
         place = src.find { |item| item["code"] == birthplace_code && in_dates?(item) }
 
         if place.nil?
-          birthplace(utils.countries, stop: true) unless stop
-        else
-          place.to_h.transform_keys(&:to_sym)
+          return birthplace(utils.countries, stop: true) unless stop
+
+          raise InvalidTaxCodeError
         end
+
+        place.to_h.transform_keys(&:to_sym)
       end
 
       def birthplace_code

--- a/test/itax_code/parser_test.rb
+++ b/test/itax_code/parser_test.rb
@@ -29,9 +29,8 @@ module ItaxCode
       end
     end
 
-    # FIXME: This behaviour needs to be fixed, maybe by raising an InvalidTaxCodeError.
-    test "returns nil birthplace when the lookup on both cities and countries fails" do
-      assert_nil klass.new("BRRDRN70M41ZXXXE").decode[:birthplace]
+    test "raises InvalidTaxCodeError when birthplace code is not found in cities or countries" do
+      assert_raises(klass::InvalidTaxCodeError) { klass.new("BRRDRN70M41ZXXXE").decode }
     end
 
     test "raises NoTaxCodeError with an empty tax code" do


### PR DESCRIPTION
## Summary

- `Parser#birthplace` silently returned `nil` when neither cities nor countries contained the decoded birthplace code. The `stop: true` branch fell off the end without an explicit return or raise.
- Fixed by adding `raise InvalidTaxCodeError` after the recursive countries fallback fails.
- Updated the FIXME test to `assert_raises` and removed the FIXME comment.
- Updated `AGENTS.md` to document the new behaviour (`raises InvalidTaxCodeError` instead of `nil`).

## Test plan

- [ ] `bundle exec rake` green with 100% line + branch coverage
- [ ] `bundle exec rubocop` clean on changed files
- [ ] Merge **before** `test/coverage-gaps` (that branch's T4 test depends on this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tax code parsing now raises an error when birthplace cannot be found, instead of returning null.

* **Documentation**
  * Updated API documentation to reflect that invalid birthplace lookups now raise an error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matteoredz/itax-code/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->