### PR TITLE
fix(encoder): replace values_at with string slicing to avoid latent nil

### DIFF
--- a/lib/itax_code/encoder.rb
+++ b/lib/itax_code/encoder.rb
@@ -63,7 +63,7 @@ module ItaxCode
         consonants = utils.extract_consonants chars
         vowels     = utils.extract_vowels chars
 
-        consonants = consonants.chars.values_at(0, 2..consonants.size).join if consonants.length > 3
+        consonants = (consonants[0] + consonants[2..-1]).to_s if consonants.length > 3
 
         "#{consonants[0..2]}#{vowels[0..2]}XXX"[0..2].upcase
       end

--- a/test/itax_code/encoder_test.rb
+++ b/test/itax_code/encoder_test.rb
@@ -43,6 +43,17 @@ module ItaxCode
                    ).encode
     end
 
+    test "#encode when name has 5 consonants skips the 2nd consonant" do
+      assert_equal "RSSVNT80A01F205L",
+                   Encoder.new(
+                     surname: "Rossi",
+                     name: "Valentino",
+                     gender: "M",
+                     birthdate: "1980-01-01",
+                     birthplace: "Milano"
+                   ).encode
+    end
+
     test "#encode for foreign countries" do
       assert_equal "BRRDRN70M41Z602D",
                    Encoder.new(


### PR DESCRIPTION
## Summary

- `encode_name` used `consonants.chars.values_at(0, 2..consonants.size).join` to skip the 2nd consonant when a name has more than 3 consonants.
- `2..consonants.size` exceeds valid indices by 1; `Array#values_at` returns `nil` for the out-of-bounds index, which `join` silently discards — producing correct output by accident.
- Replaced with `(consonants[0] + consonants[2..-1]).to_s`, which is explicit, nil-free, and Ruby 2.5-safe.
- Added a regression test with a 5-consonant name ("Valentino") to document the expected behaviour.

## Test plan

- [ ] `bundle exec rake` green with 100% line + branch coverage
- [ ] `bundle exec rubocop` clean on changed files
- [ ] Independent of the other branches — can merge in any order

🤖 Generated with [Claude Code](https://claude.com/claude-code)